### PR TITLE
Fix static scan issues

### DIFF
--- a/gnu-efi-3.0/lib/misc.c
+++ b/gnu-efi-3.0/lib/misc.c
@@ -403,9 +403,7 @@ LibInsertToTailOfBootOrder (
                 VarSize, (VOID*) NewBootOptionArray
                 );
 
-    if (NewBootOptionArray) {
-        FreePool (NewBootOptionArray);
-    }
+    FreePool (NewBootOptionArray);
     if (BootOptionArray) {
         FreePool (BootOptionArray);
     }


### PR DESCRIPTION
There may be a null pointer dereference, or else the comparison against null is unnecessary.