### PR TITLE
Use default division method instead of ASM

### DIFF
--- a/gnu-efi-3.0/lib/ia32/math.c
+++ b/gnu-efi-3.0/lib/ia32/math.c
@@ -140,7 +140,7 @@ DivU64x32 (
 // divide 64bit by 32bit and get a 64bit result
 // N.B. only works for 31bit divisors!!
 {
-#if 0 && defined(__GNUC__) && !defined(__MINGW32__)
+#if 1 && defined(__GNUC__) && !defined(__MINGW32__)
     if (Remainder)
         *Remainder = Dividend % Divisor;
     return Dividend / Divisor;


### PR DESCRIPTION
The ASM code is not working correctly, change to default method

Ori-Tracked-On: OAM-117140
Tracked-On: OAM-118547